### PR TITLE
Refactor test main arguments handling

### DIFF
--- a/chess/main.swift
+++ b/chess/main.swift
@@ -365,16 +365,16 @@ func getHumanMove(board: Board, testMode: Bool) -> Move? {
     return nil
 }
 
-func main() {
+func chessMain(arguments: [String] = CommandLine.arguments) {
     var board = Board()
     var testMode = false
 
     // if given a starting-position-pattern filename, read in that file
-    if CommandLine.arguments.count == 2 {
-        if CommandLine.arguments[1] == "-t" {
+    if arguments.count == 2 {
+        if arguments[1] == "-t" {
             testMode = true
         } else {
-            let filename = CommandLine.arguments[1]
+            let filename = arguments[1]
             do {
                 try board.loadPos(fromFile: filename)
             } catch ChessError.parse(let message) {
@@ -421,6 +421,10 @@ func main() {
             break
         }
     }
+}
+
+func main() {
+    chessMain(arguments: CommandLine.arguments)
 }
 
 main()

--- a/chess_test/chess_test.swift
+++ b/chess_test/chess_test.swift
@@ -185,11 +185,8 @@ final class ChessTests: XCTestCase {
     }
 
     func testMainWithArguments() {
-        let originalArguments = CommandLine.arguments
-
-        CommandLine.arguments = ["chess", "-t"]
         let output = captureStandardOutput {
-            main()
+            chessMain(arguments: ["chess", "-t"])
         }
         print(output)
 
@@ -201,8 +198,6 @@ final class ChessTests: XCTestCase {
                       "Output should contain diagram of computer's move.")
         XCTAssertTrue(output.contains("4:  P  -  ·  -  ·  -  ·  - "),
                       "Output should contain diagram of human's move.")
-
-        CommandLine.arguments = originalArguments
     }
 
     func testLoadPosFile() {


### PR DESCRIPTION
## Summary
- expose new `chessMain(arguments:)` function
- adapt `main()` wrapper to call it
- update `testMainWithArguments` to avoid modifying `CommandLine.arguments`

## Testing
- `swiftc -enable-bare-slash-regex chess/main.swift -o /tmp/chess`

------
https://chatgpt.com/codex/tasks/task_e_6843beebcf3c8332b24d0fc614813da2